### PR TITLE
Replaces filters when updating conditions

### DIFF
--- a/app/models/will_filter/filter.rb
+++ b/app/models/will_filter/filter.rb
@@ -439,7 +439,20 @@ module WillFilter
 
       condition_key = condition_key.to_sym if condition_key.is_a?(String)
       operator_key = operator_key.to_sym if operator_key.is_a?(String)
-      return unless valid_operator?(condition_key, operator_key)
+
+      unless valid_operator?(condition_key, operator_key)
+        # When the condition key changes, the selected operator key might not be valid.
+        # e.g.
+        #       previous condition key  = a text attribute
+        #       previous operator key   = starts with
+        #
+        #       the user changes the selected attribute to a numeric one
+        #       in this context, the "starts with" operator and its value are not valid anymore for the numeric filter
+        #
+        # wWhen this happens, we reset the filter to the new attribute's default operator and empty values.
+        operator_key = default_operator_key(condition_key).to_sym
+        values = []
+      end
 
       condition = WillFilter::FilterCondition.new(self, condition_key, operator_key, container_for(condition_key, operator_key), values)
       @conditions.insert(index, condition)


### PR DESCRIPTION
This commit fixes a bug that prevented users from changing the condition of an existing filter when the selected operator is not valid for the new condition.

The bug was fixed by resetting the selected operator and value for the new condition.